### PR TITLE
Merging forgot-password with main-backup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -415,3 +415,4 @@ Thumbs.db
 /FlaskBackend/flask_sessions/
 /AngularFrontend/package-lock.json
 /env
+/FlaskBackend/.env

--- a/AngularFrontend/src/app/app.routes.ts
+++ b/AngularFrontend/src/app/app.routes.ts
@@ -19,6 +19,7 @@ import { LogoutComponent } from './pages/logout/logout.component';
 import { AddFloorComponent } from './pages/add-floor/add-floor.component';
 import { EditFloorComponent } from './pages/edit-floor/edit-floor.component';
 import { GenerateReportComponent } from './pages/generate-report/generate-report.component';
+import { ForgotPasswordComponent } from './pages/forgot-password/forgot-password.component';
 
 export const routes: Routes = [
   { path: 'dashboard', component: DashboardComponent, canActivate: [AuthGuard] },
@@ -26,6 +27,7 @@ export const routes: Routes = [
   { path: 'add-user', component: AddUserComponent, canActivate: [AuthGuard] },
   { path: 'login', component: LoginComponent },
   { path: 'logout', component: LogoutComponent }, // navigate here to log out and clear localStorage
+  { path: 'forgot-password', component: ForgotPasswordComponent },
   { path: 'lost-and-found', component: LostAndFoundComponent },
   { path: 'add-item', component: AddItemComponent, canActivate: [AuthGuard] },
   { path: 'claimed-items', component: ClaimedItemsComponent, canActivate: [AuthGuard] },

--- a/AngularFrontend/src/app/pages/forgot-password/forgot-password.component.css
+++ b/AngularFrontend/src/app/pages/forgot-password/forgot-password.component.css
@@ -1,0 +1,183 @@
+/* Matthew Guild, Shane Petree */
+/* Styling */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f3f4f6;
+  color: #000000;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+  display: flex;
+}
+
+/* header Styles */
+header {
+  background-color: #041E42;
+  color: #ffffff;
+  padding: 20px 0;
+  margin-bottom: 20px;
+  width: 100%;
+  border-radius: 0px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo-group {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}
+
+header h1 {
+  font-size: 2.5rem;
+  margin: 0;
+}
+
+header nav ul {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 25px;
+}
+
+  header nav ul li a {
+    color: #ffffff;
+    text-decoration: none;
+    font-size: 1.2rem;
+    transition: color 0.3s ease;
+  }
+
+    header nav ul li a:hover {
+      color: #f3f4f6;
+      text-decoration: underline;
+    }
+
+.mat-form-field {
+  background-color: #ffffff;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 20px;
+  width: 100%;
+  max-width: 600px;
+  margin: 20px auto;
+}
+
+  .mat-form-field mat-select {
+    font-size: 1rem;
+    margin-top: 10px;
+    display: block;
+    color: #333;
+  }
+
+  .mat-form-field mat-option {
+    width: 100%;
+    padding: 8px;
+    margin-top: 5px;
+    margin-bottom: 15px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+  }
+
+  .mat-form-field mat-input {
+    width: 100%;
+    padding: 8px;
+    margin-top: 5px;
+    margin-bottom: 15px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+  }
+
+.forgot-password-form {
+  background-color: #ffffff;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 20px;
+  width: 100%;
+  max-width: 600px;
+  margin: 20px auto;
+}
+
+  .forgot-password-form h2 {
+    font-size: 1.8rem;
+    margin-bottom: 15px;
+    color: #041E42;
+  }
+
+  .forgot-password-form label {
+    font-size: 1rem;
+    margin-top: 10px;
+    display: block;
+    color: #333;
+  }
+
+  .forgot-password-form input[type="text"],
+  .forgot-password-form input[type="date"],
+  .forgot-password-form select,
+  .forgot-password-form textarea {
+    width: 100%;
+    padding: 8px;
+    margin-top: 5px;
+    margin-bottom: 15px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+  }
+
+  .forgot-password-form input[type="file"] {
+    padding: 8px;
+    margin-bottom: 15px;
+    display: block;
+  }
+
+  .forgot-password-form button {
+    background-color: #041E42;
+    color: #ffffff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1rem;
+  }
+
+    .forgot-password-form button:hover {
+      background-color: #003366;
+    }
+
+/* Footer */
+.footer {
+  background-color: #041E42;
+  color: white;
+  text-align: center;
+  padding: 1.5rem 1rem;
+  background-image: url("/assets/site-footer-bg.jpg");
+  background-size: cover;
+  background-position: center;
+  font-family: Arial, sans-serif;
+}
+
+  .footer p {
+    margin: 0;
+    font-size: 0.95rem;
+  }

--- a/AngularFrontend/src/app/pages/forgot-password/forgot-password.component.html
+++ b/AngularFrontend/src/app/pages/forgot-password/forgot-password.component.html
@@ -1,0 +1,70 @@
+<!--Shane Petree-->
+<div class="main-container">
+
+  <app-nav-bar></app-nav-bar>
+
+  <section class="forgot-password-form">
+    <h2>Reset Password</h2>
+    <form [formGroup]="forgotPasswordForm" (ngSubmit)="onSubmit()">
+
+      <span *ngIf="form_state === 'get_credentials'">
+        <!--input field user's NetID-->
+        <mat-form-field>
+          <mat-label>NetID</mat-label>
+          <input matInput formControlName="NetID" [value]="NetID" placeholder="tjerry" required>
+        </mat-form-field>
+        <br />
+
+        <!--input field user's email-->
+        <mat-form-field>
+          <mat-label>Email</mat-label>
+          <input matInput formControlName="email" [value]="email" placeholder="firstlast@unr.edu" required>
+        </mat-form-field>
+        <br />
+      </span>
+
+      <span *ngIf="form_state == 'check_auth_code'">
+        <!--input field user's auth_code from email-->
+        <mat-form-field>
+          <mat-label>One-Time Security Code</mat-label>
+          <input matInput formControlName="auth_code" [value]="auth_code" placeholder="_ _ _ _ _ _" required>
+        </mat-form-field>
+        <br />
+      </span>
+
+      <span *ngIf="form_state === 'check_passwords_match'">
+        <!--input field user's new password-->
+        <mat-form-field>
+          <mat-label>New Password</mat-label>
+          <input type="password" matInput formControlName="new_password" [value]="new_password" placeholder="password" required>
+        </mat-form-field>
+        <br />
+
+        <!--input field confirm user's password-->
+        <mat-form-field>
+          <mat-label>Confirm Password</mat-label>
+          <input type="password" matInput formControlName="confirm_password" [value]="confirm_password" placeholder="password" required>
+        </mat-form-field>
+        <br />
+      </span>
+
+      <!--<button type="submit" mat-flat-button [disabled]="forgotPasswordForm.invalid">Reset Password</button>-->
+      <!--<span *ngif="form_state === 'get_credentials'">
+        <button type="submit" mat-flat-button>Check Credentials</button>
+      </span>
+      <span *ngif="form_state === 'check_auth_code'">
+        <button type="submit" mat-flat-button>Check Credentials</button>
+      </span>
+      <span *ngif="form_state === 'check_passwords_match'">
+        <button type="submit" mat-flat-button>Change Password</button>
+      </span>-->
+
+      <button type="submit" mat-flat-button>Check Credentials</button>
+
+    </form>
+  </section>
+
+  <footer class="footer">
+    <p>&copy; 2025 University of Nevada, Reno. Lost and Found Service.</p>
+  </footer>
+</div>

--- a/AngularFrontend/src/app/pages/forgot-password/forgot-password.component.spec.ts
+++ b/AngularFrontend/src/app/pages/forgot-password/forgot-password.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ForgotPasswordComponent } from './forgot-password.component';
+
+describe('ForgotPasswordComponent', () => {
+  let component: ForgotPasswordComponent;
+  let fixture: ComponentFixture<ForgotPasswordComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ForgotPasswordComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(ForgotPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/AngularFrontend/src/app/pages/forgot-password/forgot-password.component.ts
+++ b/AngularFrontend/src/app/pages/forgot-password/forgot-password.component.ts
@@ -1,0 +1,219 @@
+// Shane Petree
+
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { flask_URL } from '../../app.config';
+import { HttpClient } from '@angular/common/http';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatInput } from '@angular/material/input';
+import { MatButton } from '@angular/material/button';
+import { MatOption } from '@angular/material/core';
+import { MatListModule } from '@angular/material/list';
+import { MatSelect } from '@angular/material/select';
+import { NavBarComponent } from '../../nav-bar/nav-bar.component';
+
+@Component({
+  selector: 'app-forgot-password',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatSelect,
+    MatInput,
+    MatOption,
+    MatButton,
+    MatListModule,
+    RouterLink,
+    NavBarComponent
+  ],
+  templateUrl: './forgot-password.component.html',
+  styleUrl: './forgot-password.component.css'
+})
+export class ForgotPasswordComponent {
+  forgotPasswordForm: FormGroup;
+  NetID: string | null = null;
+  email: string | null = null;
+  new_password: string | null = null;
+  confirm_password: string | null = null;
+  auth_code: number | null = null;
+  form_state: string = 'get_credentials';    // 'get_credentials', 'check_auth_code', 'check_passwords_match'
+
+  constructor(private fb: FormBuilder, private http: HttpClient, private router: Router) {
+    this.forgotPasswordForm = this.fb.group({
+      NetID: [this.NetID, Validators.required],
+      email: [this.email, Validators.required],
+      auth_code: [this.auth_code, Validators.required],
+      new_password: [this.new_password, Validators.required],
+      confirm_password: [this.confirm_password, Validators.required],
+    });
+  }
+
+  onSubmit() {
+    this.getFormValues();
+
+    // getting the NetID and email from the user, and checking if the user exists
+    if (this.form_state == 'get_credentials') {
+      this.checkUserRequest();
+    }
+
+    // checking the security auth_code from the email
+    if (this.form_state == 'check_auth_code') {
+      this.checkAuthCode();
+    }
+
+    // checking if the new passwords match
+    if (this.form_state == 'check_passwords_match') {
+      if (this.new_password == this.confirm_password) {
+        this.changePassword();
+      }
+      else
+      {
+        alert("Passwords do not match.");
+        this.clearPasswords();
+      }
+    }
+  }
+
+  checkUserRequest() {
+    //! TEST PRINT
+    //console.log(`NetID: ${this.NetID}`);
+    //console.log(`email: ${this.email}`);
+
+    const url = `${flask_URL}/checkuser`;
+
+    const formData = new FormData();
+    formData.append('username', this.NetID.toString());
+    formData.append('email', this.email.toString());
+
+    return this.http.post(url, formData, { withCredentials: true }).subscribe(
+      {
+        next: data => {
+          console.log("Data received:", data);
+          alert("A security code was sent to your email.\nPlease enter your one-time security code.");
+          this.form_state = 'check_auth_code';
+        },
+        error: error => {
+          console.error("Error: ", error);
+          alert(`Error: Invalid credentials.`);
+          this.form_state = 'get_credentials';
+          this.clearCredentials();
+        },
+      }
+    );
+  }
+
+  checkAuthCode() {
+    //! TEST PRINT
+    //console.log(`NetID: ${this.NetID}`);
+    //console.log(`email: ${this.email}`);
+
+    const url = `${flask_URL}/forgotpassword`;
+
+    const formData = new FormData();
+    formData.append('username', this.NetID.toString());
+    formData.append('email', this.email.toString());
+    //formData.append('new_password', this.new_password.toString());
+    formData.append('auth_code', this.auth_code.toString());
+    formData.append('action', 'check_auth_code');
+
+    return this.http.post(url, formData, { withCredentials: true }).subscribe(
+      {
+        next: data => {
+          console.log("Data received:", data);
+          alert("Please enter your new password.");
+          this.form_state = 'check_passwords_match';
+        },
+        error: error => {
+          console.error("Error: ", error);
+          alert(`Error: Incorrect security code.`);
+          this.clearAuthToken();
+          //this.form_state = 0;
+        },
+      }
+    );
+  }
+
+  changePassword() {
+    const url = `${flask_URL}/forgotpassword`;
+
+    const formData = new FormData();
+    formData.append('username', this.NetID.toString());
+    formData.append('email', this.email.toString());
+    formData.append('new_password', this.new_password.toString());
+    formData.append('auth_code', this.auth_code.toString());
+    formData.append('action', 'change_password');
+
+    return this.http.post(url, formData, { withCredentials: true }).subscribe(
+      {
+        next: data => {
+          console.log("Data received:", data);
+          alert("Password successfully changed.");
+          //this.form_state = 0;
+
+          // navigate to login
+          this.router.navigate(['/login']);
+        },
+        error: error => {
+          console.error("Error: ", error);
+          alert(`Error: Failed to update password.`);
+          this.clearPasswords();
+          //this.form_state = 0;
+        },
+      }
+    );
+  }
+
+  getFormValues(): void {
+    this.NetID = this.forgotPasswordForm.get<string>('NetID').value;
+    this.email = this.forgotPasswordForm.get<string>('email').value;
+    this.auth_code = this.forgotPasswordForm.get<string>('auth_code').value;
+    this.new_password = this.forgotPasswordForm.get<string>('new_password').value;
+    this.confirm_password = this.forgotPasswordForm.get<string>('confirm_password').value;
+  }
+
+  resetForm(): void {
+    this.forgotPasswordForm.patchValue({
+      'NetID': null,
+      'email': null,
+      'auth_code': null,
+      'new_password': null,
+      'confirm_password': null,
+    });
+    this.NetID = null;
+    this.email = null;
+    this.auth_code = null;
+    this.new_password = null;
+    this.confirm_password = null;
+    // initial state when you open the form
+    this.form_state = 'get_credentials';
+  }
+
+  clearCredentials(): void {
+    this.forgotPasswordForm.patchValue({
+      'NetID': null,
+      'email': null,
+    });
+    this.NetID = null;
+    this.email = null;
+  }
+
+  clearAuthToken(): void {
+    this.forgotPasswordForm.patchValue({
+      'auth_code': null,
+    });
+    this.auth_code = null;
+  }
+
+  clearPasswords(): void {
+    this.forgotPasswordForm.patchValue({
+      'new_password': null,
+      'confirm_password': null,
+    });
+    this.new_password = null;
+    this.confirm_password = null;
+  }
+
+}

--- a/AngularFrontend/src/app/pages/login/login.component.html
+++ b/AngularFrontend/src/app/pages/login/login.component.html
@@ -1,4 +1,4 @@
-<!--Mary Cottier, Matthew Guild-->
+<!--Mary Cottier, Matthew Guild, Shane Petree-->
 <!-- HEADER -->
 <header class="header">
   <div class="top-bar">
@@ -36,7 +36,8 @@
         <button mat-button type="submit">Next</button>
       </form>      
       <div class="signin-options">
-        <button class="signin-option-btn">Sign-in options</button>
+        <!--<button class="signin-option-btn">Sign-in options</button>-->
+        <button class="signin-option-btn" routerLink="/forgot-password">Forgot Password?</button>
       </div>
     </div>
   </div>

--- a/AngularFrontend/src/app/pages/logout/logout.component.ts
+++ b/AngularFrontend/src/app/pages/logout/logout.component.ts
@@ -28,7 +28,6 @@ export class LogoutComponent implements OnInit {
       alert('Your session has been closed.');
     }
 
-    // Redirect to your desired route
     this.router.navigate(['/map']);
   }
 }

--- a/FlaskBackend/FlaskBackend.pyproj
+++ b/FlaskBackend/FlaskBackend.pyproj
@@ -34,6 +34,7 @@
     <Compile Include="HelloFlask\createTables.py" />
     <Compile Include="HelloFlask\db.py" />
     <Compile Include="HelloFlask\init_db.py" />
+    <Compile Include="HelloFlask\init_mail.py" />
     <Compile Include="HelloFlask\module1.py" />
     <Compile Include="HelloFlask\queries.py" />
     <Compile Include="HelloFlask\runserver.py" />

--- a/FlaskBackend/HelloFlask/AccountLogicViews.py
+++ b/FlaskBackend/HelloFlask/AccountLogicViews.py
@@ -1,4 +1,5 @@
 # Guilherme Cassiano, Shane Petree, Mary Cottier
+
 from pickle import TRUE
 from flask import Blueprint, jsonify, render_template, request, redirect, url_for, flash, session, make_response
 from HelloFlask.queries import Queries  
@@ -10,13 +11,18 @@ import json
 import uuid
 from collections import defaultdict
 from datetime import datetime
+import random
+
+from flask_mail import Message
+from HelloFlask.init_mail import mail
+
 # Instance of Queries for database access
 db_queries = Queries()
 account_bp = Blueprint('account', __name__)
 
 # handles the login http request from angular
 @account_bp.route('/login', methods=['POST'])
-@cross_origin(supports_credentials=True) 
+@cross_origin(supports_credentials=True)
 def login():
     data = request.get_json() # Get the JSON data from the request
     username = data.get('NetId')
@@ -54,6 +60,126 @@ def logout():
     db_queries.updateUserToken(session['user_id'])
     session.clear()
     return redirect(url_for('main.home'))
+
+# checks if the user account exists, not needed? DELETE IF NOT USED
+@account_bp.route('/checkuser', methods=['POST'])
+@cross_origin(supports_credentials=True)
+def checkUser():
+    if request.method == 'POST':
+        username = request.form.get('username')
+        email = request.form.get('email')
+
+        # TEST PRINT
+        # print(username)
+        # print(email)
+
+        # get user from NetID
+        user = db_queries.getUserAll(username)
+
+        # TEST PRINT
+        # print(f'usernames match: ', {(user['username'] == username)})
+        # print(f'emails match: ', {(user['email'] == email)})
+
+        # if the user exists, then the reset password email can be sent
+        if user and user['active'] == True and user['username'] == username and user['email'] == email:
+            
+            # create the n (6) digit temp code
+            n = 6
+            range_start = 10**(n-1)
+            range_end = (10**n)-1
+            auth_code = str(random.randint(range_start, range_end))
+
+            # TEST PRINT
+            # print(f'auth_code: {auth_code}')
+
+            # update user's auth token with temp auth code
+            # db_queries.updateUserToken(user['uid'], )
+            db_queries.updateUserToken(user['uid'], auth_code)
+
+            # check if the user's authtoken was updated
+            user = db_queries.getUserAll(username)
+
+            # TEST PRINT
+            # print(f'authtokens match: ', {(user['authtoken'] == auth_code)})
+
+            if user and user['authtoken'] == auth_code:
+
+                # send password reset email
+                msg = Message(
+                    subject = "Your one-time password reset code",
+                    sender = os.getenv("EMAIL"),
+                    # recipients = [os.getenv("TEMP_EMAIL")],
+                    recipients = [email],
+
+                )
+                msg.body = f'Your one-time password reset code \n\n {auth_code}'
+                mail.send(msg)
+            
+                return jsonify({
+                    'success': True,
+                }), 200
+            else:
+                # change this message after it works
+                jsonify({"error": "Authoken was not updated"}), 401
+
+        else:
+            return jsonify({"error": "Unauthorized"}), 401
+        # formAuthToken = request.form.get('authToken')
+        
+    else:
+        return jsonify({"error": "Unauthorized"}), 401
+
+@account_bp.route('/forgotpassword', methods=['GET', 'POST'])
+@cross_origin(supports_credentials=True)
+def forgotPassword():
+    if request.method == 'POST':
+        username = request.form.get('username')
+        email = request.form.get('email')
+        new_password = request.form.get('new_password')
+        auth_code = request.form.get('auth_code')
+        action = request.form.get('action')
+
+        # get user from NetID
+        user = db_queries.getUserAll(username)
+        
+        # change the password if the passwords match and the auth_code matches db/email
+        if action == 'change_password':
+
+            # if the user exists, and sent the correct auth code, then the user's password can be reset
+            if user and user['active'] == True and user['username'] == username and user['email'] == email and user['authtoken'] == auth_code:
+            
+                hashed_password = generate_password_hash(new_password)
+                db_queries.updateUserPassword(user['uid'], hashed_password)
+
+                # check if the password was updated in DB
+                user = db_queries.getUserAll(username)
+
+                if user and user['password'] == hashed_password:
+                    return jsonify({
+                        'success': True,
+                    }), 200
+                else:
+                    # change this message after it works
+                    return jsonify({"error": "Password was not updated"}), 401
+
+            else:
+                return jsonify({"error": "Unauthorized"}), 401
+    
+        # check if the auth_code is valid
+        if action == 'check_auth_code':
+            if user and user['active'] == True and user['username'] == username and user['email'] == email and user['authtoken'] == auth_code:
+
+                if user and user['authtoken'] == auth_code:
+                    return jsonify({
+                        'success': True,
+                    }), 200
+                else:
+                    # change this message after it works
+                    return jsonify({"error": "Incorrect security code"}), 401
+    
+    else:
+        return jsonify({"error": "Unauthorized"}), 401
+
 
 @account_bp.route('/adduser', methods=['GET', 'POST'])
 @cross_origin(supports_credentials=True) 
@@ -95,7 +221,6 @@ def addUser():
                         print(f"Invalid line format: {line.strip()}")
 
             os.remove(file_path)
-            #return redirect(url_for('account.addUser',buildingsDisplay=buildingsDisplay ))
 
         # Check for single-user form submission
         username = request.form.get('netID')
@@ -113,8 +238,10 @@ def addUser():
 
         if all([username, password, email, buildings]):
             # Validate and process single-user form submission
-            if not email.endswith('@unr.edu'):
-                return jsonify({"error": "Email is not valid"}), 400
+            #! UNCOMMENT AFTER EMAIL WORKS----------------------------------------------------------------------------
+            # if not email.endswith('@unr.edu'):
+            #     return jsonify({"error": "Email is not valid"}), 400
+
             #hash user passowrd
             hashed_password = generate_password_hash(password)
             #create account 

--- a/FlaskBackend/HelloFlask/AccountLogicViews.py
+++ b/FlaskBackend/HelloFlask/AccountLogicViews.py
@@ -83,7 +83,7 @@ def logout():
     session.clear()
     return redirect(url_for('main.home'))
 
-# checks if the user account exists, not needed? DELETE IF NOT USED
+# checks if the user account exists
 @account_bp.route('/checkuser', methods=['POST'])
 @cross_origin(supports_credentials=True)
 def checkUser():
@@ -146,11 +146,11 @@ def checkUser():
 
         else:
             return jsonify({"error": "Unauthorized"}), 401
-        # formAuthToken = request.form.get('authToken')
         
     else:
         return jsonify({"error": "Unauthorized"}), 401
 
+# lets the user change their password if theit auth_code from their email is correct
 @account_bp.route('/forgotpassword', methods=['GET', 'POST'])
 @cross_origin(supports_credentials=True)
 def forgotPassword():

--- a/FlaskBackend/HelloFlask/__init__.py
+++ b/FlaskBackend/HelloFlask/__init__.py
@@ -1,3 +1,6 @@
+# Guilherme Cassiano, Mary Cottier, Shane Petree
+
+from os import getenv
 from flask import Flask, session, redirect, url_for, jsonify, request
 from HelloFlask.views import main_bp
 from HelloFlask.AccountLogicViews import account_bp
@@ -5,14 +8,20 @@ from HelloFlask.queries import Queries
 from flask_cors import CORS
 from datetime import timedelta, datetime
 import time
+from dotenv import load_dotenv
+
+# load env variables
+load_dotenv('.env')
 
 def create_app():
-    app = Flask(__name__)
-    # Allow all origins for now — you can lock this down later
+    app = Flask(__name__)    
+    # Allow all origins for now, you can lock this down later
     CORS(app, resources={r"/*": {"origins": "*"}}, supports_credentials=True)
 
+    # set debug mode
+    # app.config['DEBUG'] = getenv("DEBUG")
 
-    app.secret_key = 'sMcP4D0JVI0i'
+    app.secret_key = getenv("FLASK_APP_KEY")
     app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(minutes=15)
     app.register_blueprint(main_bp)
     app.register_blueprint(account_bp)

--- a/FlaskBackend/HelloFlask/checktables.py
+++ b/FlaskBackend/HelloFlask/checktables.py
@@ -1,11 +1,16 @@
-# Implemented by Guilherme Domingues Cassiano 
+# Guilherme Domingues Cassiano, Shane Petree
 import psycopg2
+from os import getenv
+from dotenv import load_dotenv
+
+# load env variables
+load_dotenv('.env')
 
 def check_table_schema(table_name):
     conn = psycopg2.connect(
-        dbname="TestDB",
+        dbname="testdb",
         user="postgres",
-        password="#aH6TR5fkcdx99",
+        password=getenv("DATABASE_PASSWORD"),
         host="localhost",
         port="5432"
     )

--- a/FlaskBackend/HelloFlask/createTables.py
+++ b/FlaskBackend/HelloFlask/createTables.py
@@ -1,13 +1,19 @@
-# File implemented by Guilherme Domingues Cassiano 
+# Guilherme Domingues Cassiano, Shane Petree 
+
 import psycopg2
 from psycopg2 import sql
+from os import getenv
+from dotenv import load_dotenv
+
+# load env variables
+load_dotenv('.env')
 
 def create_tables():
     # Connect to the 'TestDB' database
     conn = psycopg2.connect(
-        dbname="TestDB",
+        dbname="testdb",
         user="postgres",
-        password="#aH6TR5fkcdx99",
+        password=getenv("DATABASE_PASSWORD"),
         host="localhost",
         port="5432"
     )

--- a/FlaskBackend/HelloFlask/db.py
+++ b/FlaskBackend/HelloFlask/db.py
@@ -1,15 +1,21 @@
-# File implemented by Guilherme Domingues Cassiano
+# Guilherme Domingues Cassiano, Shane Petree
+
 import psycopg2
 from psycopg2 import sql
 from flask import g  # 'g' is Flask's global context for request-scoped variables
 from HelloFlask import app
+from os import getenv
+from dotenv import load_dotenv
+
+# load env variables
+load_dotenv('.env')
 
 def get_db():
     if 'db' not in g:
         g.db = psycopg2.connect(
-            dbname="TestDB",
+            dbname="testdb",
             user="postgres",
-            password="#aH6TR5fkcdx99",
+            password=getenv("DATABASE_PASSWORD"),
             host="localhost",
             port="5432"
         )

--- a/FlaskBackend/HelloFlask/init_mail.py
+++ b/FlaskBackend/HelloFlask/init_mail.py
@@ -1,0 +1,29 @@
+# Shane Petree
+
+from os import getenv
+from flask import Flask
+from flask_mail import Mail
+from dotenv import load_dotenv
+
+# load env variables
+load_dotenv('.env')
+
+mail = Mail()
+
+def create_mail_app():
+    mail_app = Flask(__name__)
+
+    # flask-mail email config
+    mail_app.config['MAIL_SERVER'] = 'smtp.gmail.com'
+    mail_app.config['MAIL_PORT'] = 587         # getenv("MAIL_PORT")
+    mail_app.config['MAIL_USE_TLS'] = True
+    mail_app.config['MAIL_USE_SSL'] = False
+    mail_app.config['MAIL_USERNAME'] = getenv("EMAIL")
+    mail_app.config['MAIL_PASSWORD'] = getenv("GMAIL_APP_PASSWORD")
+    mail_app.config['MAIL_DEFAULT_SENDER'] = getenv("EMAIL")
+
+    mail.init_app(mail_app)
+
+    return mail_app
+
+mail = Mail(create_mail_app())

--- a/FlaskBackend/HelloFlask/queries.py
+++ b/FlaskBackend/HelloFlask/queries.py
@@ -240,7 +240,7 @@ class Queries:
                 WHERE uid IN ({placeholders}) AND role = %s AND active = %s
             """
             self.cursor.execute(query, tuple(uid_list) + (roles,) + (active,))
-            rows = self.cursor.fetchall()
+        rows = self.cursor.fetchall()
 
         if not rows: 
             return "none"

--- a/FlaskBackend/HelloFlask/queries.py
+++ b/FlaskBackend/HelloFlask/queries.py
@@ -1,14 +1,21 @@
-# Guilherme Cassiano
+# Guilherme Cassiano, Shane Petree
+
 import psycopg2
 from psycopg2 import sql
 from werkzeug.security import generate_password_hash, check_password_hash
+from os import getenv
+from dotenv import load_dotenv
+
+# load env variables
+load_dotenv('.env')
+
 class Queries:
     def __init__(self):
         # Initialize the connection to the database
         self.conn = psycopg2.connect(
             dbname="testdb", 
             user="postgres",
-            password="#aH6TR5fkcdx99",
+            password=getenv("DATABASE_PASSWORD"),
             host="localhost",
             port="5432"
         )
@@ -187,6 +194,28 @@ class Queries:
             return {"uid": row[0], "username": row[1], "password": row[2], "role": row[3], "active": row[4]}  
         return None
 
+    # get all values of a user to check if that user exists
+    def getUserAll(self, username):
+        self.cursor.execute("""
+        SELECT uid, username, password, email, role, active, authtoken
+        FROM users 
+        WHERE username = %s
+        """, (username,))
+        row = self.cursor.fetchone()
+        if row:
+            # Convert rows to a list of dictionaries
+            return {"uid": row[0], "username": row[1], "password": row[2], "email": row[3], "role": row[4], "active": row[5], "authtoken": row[6]}
+        return None
+
+    # query lets the user change/reset their password
+    def updateUserPassword(self, uid, password):
+        query = """
+            UPDATE users
+            SET password = %s
+            WHERE uid = %s
+        """
+        self.cursor.execute(query, (password, uid))
+        self.conn.commit()
 
     # Query to get all users for the "void" user page
     def getUserVoid(self, role, active): #*
@@ -579,9 +608,6 @@ class Queries:
 if __name__ == "__main__":
     # Create an instance of Queries
     db_queries = Queries()
-    
-    
-
     
     # Close the database connection
     db_queries.close()

--- a/FlaskBackend/HelloFlask/runserver.py
+++ b/FlaskBackend/HelloFlask/runserver.py
@@ -1,4 +1,5 @@
-# Shane Petree and Guilherme Cassiano
+# Shane Petree, Guilherme Cassiano
+
 import os
 from HelloFlask import app    # Imports the code from HelloFlask/__init__.py
 

--- a/FlaskBackend/HelloFlask/tableEdit.py
+++ b/FlaskBackend/HelloFlask/tableEdit.py
@@ -1,12 +1,18 @@
-# File implemented by Guilherme Domingues Cassiano 
+# Guilherme Domingues Cassiano, Shane Petree
+
 import psycopg2
 from psycopg2 import sql
+from os import getenv
+from dotenv import load_dotenv
+
+# load env variables
+load_dotenv('.env')
 
 def connect_db():
     conn = psycopg2.connect(
-        dbname="TestDB",
+        dbname="testdb",
         user="postgres",
-        password="#aH6TR5fkcdx99",
+        password=getenv("DATABASE_PASSWORD"),
         host="localhost",
         port="5432"
     )

--- a/FlaskBackend/HelloFlask/views.py
+++ b/FlaskBackend/HelloFlask/views.py
@@ -1,5 +1,5 @@
-# This file was implemented by Guilherme Domingues Cassiano
-# A section by Shane Petree
+# Guilherme Domingues Cassiano, Shane Petree
+
 from flask import render_template, request, redirect, url_for, Blueprint, jsonify, session, current_app, Flask
 from HelloFlask.queries import Queries
 from datetime import datetime 
@@ -7,6 +7,10 @@ import os
 import numpy as np
 from werkzeug.utils import secure_filename
 from flask_cors import cross_origin
+
+from flask_mail import Message
+from HelloFlask.init_mail import mail
+
 # Create an instance of the Queries class for database operations
 db_queries = Queries()
 main_bp = Blueprint('main', __name__)

--- a/FlaskBackend/requirements.txt
+++ b/FlaskBackend/requirements.txt
@@ -2,3 +2,5 @@ Flask>=2.2.3
 psycopg2-binary>=2.9.3
 Flask-Cors>=3.0.8
 numpy>=1.24.0
+Flask-Mail==0.9.0
+python-dotenv>=1.1.0


### PR DESCRIPTION
Bringing in the forgot password functionality into main.

- Created the Forgot-Password page
- Added Flask-Mail to requirements.txt to send emails with Flask.
- Added python-dotenv to get env variables for secret keys.
- Updated routes.ts to include the new route.
- Added an .env variable file to .gitignore, it SHOULD NOT go into github.

- Updated the app security in FlaskBackend files to save/get secret keys with env variables.
- Added init_mail.py to initialize the mail object from a config so we can send emails.

AccountLogicViews:
- Added the checkUser route, to check if a user exists and send an email with a security code to the user.
- Added the forgotPassword route to check the security code entered by the user, and then change the user's password.

Queries:
- Added the getUserAll query to get all attributes of a user.
- Added the updateUserPassword query to change the user's password.